### PR TITLE
[PLAT-2507] Build using opentdf/client-conan recipe instead of CCI version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ env:
   VCONAN_VER: 1.59.0
   # Would be nice if this value was set automagically when client-cpp is released and consumed everywhere
   VCLIENT_CPP_VER: 1.4.0
-  VCONAN_BRANCH_VERSION: True
+  VCONAN_BRANCH_VERSION: "True"
   # recipe should usually pull from 'main' but can be changed to a branch name if recipe changes are pending
   VCONAN_RECIPE_VER: main
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
 
       - name: Check out client-cpp code
         uses: actions/checkout@v2
+        with:
           repository: opentdf/client-cpp
           ref: 1.4.0
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,14 +21,15 @@ jobs:
       - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
 
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
       - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
 
       - name: Install Conan
         run: pip3 install conan==${{ env.CONAN_VER }} --force
 
       - name: Check out client-cpp code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: opentdf/client-cpp
           ref: 1.4.0
@@ -36,7 +37,8 @@ jobs:
       - name: Run client-cpp build
         run: |
           cd ${{ github.workspace }}
-          cd ../client-cpp/src
+          ls -al
+          cd client-cpp/src
           ./build-all.sh
 
       - name: Run build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,12 +9,12 @@ on:
     - cron: "0 7 * * 1,3,5"
 env:
   VBUILD_UNIT_TESTS: false
-  CONAN_VER: 1.59.0
+  VCONAN_VER: 1.59.0
   # Would be nice if this value was set automagically when client-cpp is released and consumed everywhere
-  CLIENT_CPP_VER: 1.4.0
-  CONAN_BRANCH_VERSION: True
+  VCLIENT_CPP_VER: 1.4.0
+  VCONAN_BRANCH_VERSION: True
   # recipe should usually pull from 'main' but can be changed to a branch name if recipe changes are pending
-  CONAN_RECIPE_VER: main
+  VCONAN_RECIPE_VER: main
 jobs:
 
   run-build-ubuntu:
@@ -31,20 +31,20 @@ jobs:
       - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
 
       - name: Install Conan
-        run: pip3 install conan==${{ env.CONAN_VER }} --force
+        run: pip3 install conan==${{ env.VCONAN_VER }} --force
 
       - name: Check out client-cpp code
         uses: actions/checkout@v3
         with:
           repository: opentdf/client-conan
-          ref: ${{ CONAN_RECIPE_VER }}
+          ref: ${{ env.VCONAN_RECIPE_VER }}
           path: client-conan
 
       - name: Get client-cpp into conan local cache, built from repo if necessary
         run: |
           cd ${{ github.workspace }}
           cd client-conan
-          conan create recipe/all opentdf-client/${{ env.CLIENT_CPP_VER }}@ -pr:b=default --build=opentdf-client --build=missing -o opentdf-client:branch_version=${{ env.CONAN_BRANCH_VERSION }}
+          conan create recipe/all opentdf-client/${{ env.CLIENT_CPP_VER }}@ -pr:b=default --build=opentdf-client --build=missing -o opentdf-client:branch_version=${{ env.VCONAN_BRANCH_VERSION }}
 
       - name: Run build
         run: |
@@ -78,20 +78,20 @@ jobs:
       - run: echo "💡 The %github.repository% repository has been cloned to the runner."
 
       - name: Install Conan
-        run: pip3 install conan==${{ env.CONAN_VER }} --force
+        run: pip3 install conan==${{ env.VCONAN_VER }} --force
 
       - name: Check out client-cpp code
         uses: actions/checkout@v3
         with:
           repository: opentdf/client-conan
-          ref: ${{ CONAN_RECIPE_VER }}
+          ref: ${{ env.VCONAN_RECIPE_VER }}
           path: client-conan
 
       - name: Get client-cpp into conan local cache, built from repo if necessary
         run: |
           cd ${{ github.workspace }}
           cd client-conan
-          conan create recipe/all opentdf-client/${{ env.CLIENT_CPP_VER }}@ -pr:b=default --build=opentdf-client --build=missing -o opentdf-client:branch_version=${{ env.CONAN_BRANCH_VERSION }}
+          conan create recipe/all opentdf-client/${{ env.CLIENT_CPP_VER }}@ -pr:b=default --build=opentdf-client --build=missing -o opentdf-client:branch_version=${{ env.VCONAN_BRANCH_VERSION }}
 
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1
@@ -129,20 +129,20 @@ jobs:
             python-version: 3.11
 
       - name: Install Conan
-        run: pip3 install conan==${{ env.CONAN_VER }} --force
+        run: pip3 install conan==${{ env.VCONAN_VER }} --force
 
       - name: Check out client-cpp code
         uses: actions/checkout@v3
         with:
           repository: opentdf/client-conan
-          ref: ${{ CONAN_RECIPE_VER }}
+          ref: ${{ env.VCONAN_RECIPE_VER }}
           path: client-conan
 
       - name: Get client-cpp into conan local cache, built from repo if necessary
         run: |
           cd ${{ github.workspace }}
           cd client-conan
-          conan create recipe/all opentdf-client/${{ env.CLIENT_CPP_VER }}@ -pr:b=default --build=opentdf-client --build=missing -o opentdf-client:branch_version=${{ env.CONAN_BRANCH_VERSION }}
+          conan create recipe/all opentdf-client/${{ env.CLIENT_CPP_VER }}@ -pr:b=default --build=opentdf-client --build=missing -o opentdf-client:branch_version=${{ env.VCONAN_BRANCH_VERSION }}
 
       - name: Run build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,8 @@ env:
   # Would be nice if this value was set automagically when client-cpp is released and consumed everywhere
   CLIENT_CPP_VER: 1.4.0
   CONAN_BRANCH_VERSION: True
-  # TODO- rename this to 'main' after the recipe PR below is merged and before this PR is merged
-  CONAN_RECIPE_VER: PLAT-2507-build-without-CCI
+  # recipe should usually pull from 'main' but can be changed to a branch name if recipe changes are pending
+  CONAN_RECIPE_VER: main
 jobs:
 
   run-build-ubuntu:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,11 +33,13 @@ jobs:
         with:
           repository: opentdf/client-cpp
           ref: 1.4.0
+          path: client-cpp
 
       - name: Run client-cpp build
         run: |
           cd ${{ github.workspace }}
           ls -al
+          ls -al client-cpp
           cd client-cpp/src
           ./build-all.sh
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,13 @@ jobs:
       - name: Install Conan
         run: pip3 install conan==${{ env.CONAN_VER }} --force
 
+      - name: Run client-cpp build
+        run: |
+          cd ${{ github.workspace }}
+          git clone git@github.com:opentdf/client-cpp.git
+          cd client-cpp/src
+          ./build-all.sh
+
       - name: Run build
         run: |
           cd ${{ github.workspace }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,17 +31,17 @@ jobs:
       - name: Check out client-cpp code
         uses: actions/checkout@v3
         with:
-          repository: opentdf/client-cpp
-          ref: 1.4.0
-          path: client-cpp
+          repository: opentdf/client-conan
+          ref: PLAT-2507-build-without-CCI
+          path: client-conan
 
       - name: Run client-cpp build
         run: |
           cd ${{ github.workspace }}
           ls -al
-          ls -al client-cpp
-          cd client-cpp/src
-          ./build-all.sh
+          ls -al client-conan
+          cd client-conan
+          conan create recipe/all opentdf-client/1.4.0@ -pr:b=default --build=opentdf-client --build=missing -o opentdf-client:branch_version=True
 
       - name: Run build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,11 +27,15 @@ jobs:
       - name: Install Conan
         run: pip3 install conan==${{ env.CONAN_VER }} --force
 
+      - name: Check out client-cpp code
+        uses: actions/checkout@v2
+          repository: opentdf/client-cpp
+          ref: 1.4.0
+
       - name: Run client-cpp build
         run: |
           cd ${{ github.workspace }}
-          git clone git@github.com:opentdf/client-cpp.git
-          cd client-cpp/src
+          cd ../client-cpp/src
           ./build-all.sh
 
       - name: Run build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           cd ${{ github.workspace }}
           cd client-conan
-          conan create recipe/all opentdf-client/${{ env.CLIENT_CPP_VER }}@ -pr:b=default --build=opentdf-client --build=missing -o opentdf-client:branch_version=${{ env.VCONAN_BRANCH_VERSION }}
+          conan create recipe/all opentdf-client/${{ env.VCLIENT_CPP_VER }}@ -pr:b=default --build=opentdf-client --build=missing -o opentdf-client:branch_version=${{ env.VCONAN_BRANCH_VERSION }}
 
       - name: Run build
         run: |
@@ -91,7 +91,7 @@ jobs:
         run: |
           cd ${{ github.workspace }}
           cd client-conan
-          conan create recipe/all opentdf-client/${{ env.CLIENT_CPP_VER }}@ -pr:b=default --build=opentdf-client --build=missing -o opentdf-client:branch_version=${{ env.VCONAN_BRANCH_VERSION }}
+          conan create recipe/all opentdf-client/${{ env.VCLIENT_CPP_VER }}@ -pr:b=default --build=opentdf-client --build=missing -o opentdf-client:branch_version=${{ env.VCONAN_BRANCH_VERSION }}
 
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1
@@ -142,7 +142,7 @@ jobs:
         run: |
           cd ${{ github.workspace }}
           cd client-conan
-          conan create recipe/all opentdf-client/${{ env.CLIENT_CPP_VER }}@ -pr:b=default --build=opentdf-client --build=missing -o opentdf-client:branch_version=${{ env.VCONAN_BRANCH_VERSION }}
+          conan create recipe/all opentdf-client/${{ env.VCLIENT_CPP_VER }}@ -pr:b=default --build=opentdf-client --build=missing -o opentdf-client:branch_version=${{ env.VCONAN_BRANCH_VERSION }}
 
       - name: Run build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,11 @@ on:
 env:
   VBUILD_UNIT_TESTS: false
   CONAN_VER: 1.59.0
+  # Would be nice if this value was set automagically when client-cpp is released and consumed everywhere
+  CLIENT_CPP_VER: 1.4.0
+  CONAN_BRANCH_VERSION: True
+  # TODO- rename this to 'main' after the recipe PR below is merged and before this PR is merged
+  CONAN_RECIPE_VER: PLAT-2507-build-without-CCI
 jobs:
 
   run-build-ubuntu:
@@ -32,16 +37,14 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: opentdf/client-conan
-          ref: PLAT-2507-build-without-CCI
+          ref: ${{ CONAN_RECIPE_VER }}
           path: client-conan
 
-      - name: Run client-cpp build
+      - name: Get client-cpp into conan local cache, built from repo if necessary
         run: |
           cd ${{ github.workspace }}
-          ls -al
-          ls -al client-conan
           cd client-conan
-          conan create recipe/all opentdf-client/1.4.0@ -pr:b=default --build=opentdf-client --build=missing -o opentdf-client:branch_version=True
+          conan create recipe/all opentdf-client/${{ env.CLIENT_CPP_VER }}@ -pr:b=default --build=opentdf-client --build=missing -o opentdf-client:branch_version=${{ env.CONAN_BRANCH_VERSION }}
 
       - name: Run build
         run: |
@@ -76,6 +79,19 @@ jobs:
 
       - name: Install Conan
         run: pip3 install conan==${{ env.CONAN_VER }} --force
+
+      - name: Check out client-cpp code
+        uses: actions/checkout@v3
+        with:
+          repository: opentdf/client-conan
+          ref: ${{ CONAN_RECIPE_VER }}
+          path: client-conan
+
+      - name: Get client-cpp into conan local cache, built from repo if necessary
+        run: |
+          cd ${{ github.workspace }}
+          cd client-conan
+          conan create recipe/all opentdf-client/${{ env.CLIENT_CPP_VER }}@ -pr:b=default --build=opentdf-client --build=missing -o opentdf-client:branch_version=${{ env.CONAN_BRANCH_VERSION }}
 
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1
@@ -114,6 +130,19 @@ jobs:
 
       - name: Install Conan
         run: pip3 install conan==${{ env.CONAN_VER }} --force
+
+      - name: Check out client-cpp code
+        uses: actions/checkout@v3
+        with:
+          repository: opentdf/client-conan
+          ref: ${{ CONAN_RECIPE_VER }}
+          path: client-conan
+
+      - name: Get client-cpp into conan local cache, built from repo if necessary
+        run: |
+          cd ${{ github.workspace }}
+          cd client-conan
+          conan create recipe/all opentdf-client/${{ env.CLIENT_CPP_VER }}@ -pr:b=default --build=opentdf-client --build=missing -o opentdf-client:branch_version=${{ env.CONAN_BRANCH_VERSION }}
 
       - name: Run build
         run: |

--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ class clientCsharpConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
 
     def requirements(self):
-        self.requires("opentdf-client/1.1.5@")
+        self.requires("opentdf-client/1.4.0@")
 
     def build(self):
         cmake = CMake(self)

--- a/virtru.i
+++ b/virtru.i
@@ -32,6 +32,7 @@ namespace std {
 %{
 #include "tdf_constants.h"
 #include "oidc_credentials.h"
+#include "tdf_assertion.h"
 #include "tdf_storage_type.h"
 #include "tdf_client_base.h"
 #include "tdf_client.h"
@@ -55,6 +56,7 @@ https://stackoverflow.com/questions/69496549/wrap-all-swig-generated-methods-in-
 
 %include "tdf_constants.h"
 %include "oidc_credentials.h"
+%include "tdf_assertion.h"
 %include "tdf_storage_type.h"
 %include "tdf_client_base.h"
 %include "tdf_client.h"


### PR DESCRIPTION
Include local build of client-cpp to populate cache with latest version instead of waiting for Conan Center Index to be updated.