### PR TITLE
[PLAT-2942] Bump openssh client version

### DIFF
--- a/docker/linux-arm/install_req.sh
+++ b/docker/linux-arm/install_req.sh
@@ -4,7 +4,7 @@ set -e -x
 apt-get update &&  apt-get install -y --no-install-recommends build-essential=12.9ubuntu3 \
   cmake=3.22.1-1ubuntu1.22.04.1 \
   git=1:2.34.1-1ubuntu1.10 \
-  openssh-client=1:8.9p1-3ubuntu0.4 \
+  openssh-client=1:8.9p1-3ubuntu0.5 \
   wget=1.21.2-2ubuntu1 \
   python3=3.10.6-1~22.04 \
   netbase=6.3 \


### PR DESCRIPTION
openssh-client=1:8.9p1-3ubuntu0.4 no longer available, update to openssh-client=1:8.9p1-3ubuntu0.5